### PR TITLE
animation decomposition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/Configure.cmake")
 
-project(Consol_Game)
+project(Game)
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/gtest")
 include_directories("${CMAKE_SOURCE_DIR}/3rdparty/gtest/googletest/include")
@@ -17,6 +17,7 @@ add_subdirectory(skills_graph)
 add_subdirectory(equipment)
 add_subdirectory(creature)
 add_subdirectory(action)
+add_subdirectory(animation)
 add_subdirectory(field)
 add_subdirectory(utils)
 add_subdirectory(tests)

--- a/action/action.cpp
+++ b/action/action.cpp
@@ -6,111 +6,6 @@ void Action::update_frame(Creature* creature, float time) {
         creature->get_frame() = 0;
 }
 
-void Action::switch_y_txt(Dirs dir, int& y_texture) {
-    switch (dir) {
-    case (Dirs::LEFT):  y_texture = 64;     break;
-    case (Dirs::RIGHT): y_texture = 192;    break;
-    case (Dirs::UP):    y_texture = 0;      break;
-    case (Dirs::DOWN):  y_texture = 128;    break;
-    }
-}
-
-void Action::move_animation(Creature* creature, Dirs dir) {
-
-    int y_texture;
-    switch_y_txt(dir, y_texture);
-    auto& pos = creature->get_pos();
-    auto& current_frame = creature->get_frame();
-    auto& armor_set = creature->get_armor();
-    auto& weapon = creature->get_weapon();
-
-    creature->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
-    creature->get_sprite().setTextureRect(
-            sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
-
-    for (int i = 0; i < armor_set.size(); ++i) {
-        if (armor_set[i] != nullptr) {
-            armor_set[i]->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
-            armor_set[i]->get_sprite().setTextureRect(
-                    sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
-        }
-    }
-
-    if (weapon != nullptr) {
-        weapon->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
-        weapon->get_sprite().setTextureRect(
-                sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
-    }
-
-    creature->direction = dir;
-}
-
-void Action::stop_animation(Creature* creature) {
-
-    int y_texture;
-    switch_y_txt(creature->direction, y_texture);
-
-    auto& armor_set = creature->get_armor();
-    auto& weapon = creature->get_weapon();
-
-    creature->get_sprite().setTextureRect(sf::IntRect({0, y_texture}, {64, 64}));
-
-    for (int i = 0; i < armor_set.size(); ++i) {
-        if (armor_set[i] != nullptr) {
-            armor_set[i]->get_sprite().setTextureRect(sf::IntRect({0, y_texture}, {64, 64}));
-        }
-    }
-
-    if (weapon != nullptr)
-        weapon->get_sprite().setTextureRect(sf::IntRect({0, y_texture}, {64, 64}));
-}
-
-void Action::hit_animation(Creature* creature) {
-
-    int y_texture;
-    switch_y_txt(creature->direction, y_texture);
-
-    auto& pos = creature->get_pos();
-    auto& current_frame = creature->get_frame();
-    auto& armor_set = creature->get_armor();
-    auto& weapon = creature->get_weapon();
-
-    creature->get_sprite().setTextureRect(
-            sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
-
-    for (int i = 0; i < armor_set.size(); ++i) {
-        if (armor_set[i] != nullptr) {
-            armor_set[i]->get_sprite().setTextureRect(
-                    sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
-        }
-    }
-
-    if (weapon != nullptr) {
-        weapon->get_sprite().setTextureRect(
-                sf::IntRect({(static_cast<int>(current_frame) + 1) * 192, y_texture * 3}, {192, 192}));
-        weapon->get_sprite().setPosition(sf::Vector2f(pos.x - 64, pos.y - 96));
-    }
-}
-
-void Action::die_animation(Creature* creature) {
-
-    auto& current_frame = creature->get_frame();
-    auto& armor_set = creature->get_armor();
-    auto& weapon = creature->get_weapon();
-
-    creature->get_sprite().setTextureRect(sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, 0}, {64, 64}));
-
-    for (int i = 0; i < armor_set.size(); ++i) {
-        if (armor_set[i] != nullptr) {
-            armor_set[i]->get_sprite().setTextureRect(
-                    sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, 0}, {64, 64}));
-        }
-    }
-
-    if (weapon != nullptr)
-        weapon->get_sprite().setTextureRect(sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, 0}, {64, 64}));
-}
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////MOVEMENTS///////////////////////////////////////////////////////////////
 
@@ -120,7 +15,7 @@ void Action::move_left(Creature* creature, float time, const std::shared_ptr<Fie
     auto y = static_cast<int>(pos.y / 32.f + 1.f);
     auto x = static_cast<int>((pos.x - time) / 32.f + 1.f);
     pos.x -= time * static_cast<float>(game_field->operator()(y, x)->get_passability() / 2.f);
-    move_animation(creature, Dirs::LEFT);
+    Animation::move_animation(creature, Dirs::LEFT);
 }
 
 void Action::move_right(Creature* creature, float time, const std::shared_ptr<Field>& game_field) {
@@ -129,7 +24,7 @@ void Action::move_right(Creature* creature, float time, const std::shared_ptr<Fi
     auto y = static_cast<int>(pos.y / 32.f + 1.f);
     auto x = static_cast<int>((pos.x + time) / 32.f + 1.f);
     pos.x += time * static_cast<float>(game_field->operator()(y, x)->get_passability() / 2.f);
-    move_animation(creature, Dirs::RIGHT);
+    Animation::move_animation(creature, Dirs::RIGHT);
 }
 
 void Action::move_up(Creature* creature, float time, const std::shared_ptr<Field>& game_field) {
@@ -138,7 +33,7 @@ void Action::move_up(Creature* creature, float time, const std::shared_ptr<Field
     auto y = static_cast<int>((pos.y - time) / 32.f + 1.f);
     auto x = static_cast<int>(pos.x / 32.f + 1.f);
     pos.y -= time * static_cast<float>(game_field->operator()(y, x)->get_passability() / 2.f);
-    move_animation(creature, Dirs::UP);
+    Animation::move_animation(creature, Dirs::UP);
 }
 
 void Action::move_down(Creature* creature, float time, const std::shared_ptr<Field>& game_field) {
@@ -147,7 +42,7 @@ void Action::move_down(Creature* creature, float time, const std::shared_ptr<Fie
     auto y = static_cast<int>((pos.y + time) / 32.f + 1.f);
     auto x = static_cast<int>(pos.x / 32.f + 1);
     pos.y += time * static_cast<float>(game_field->operator()(y, x)->get_passability() / 2.f);
-    move_animation(creature, Dirs::DOWN);
+    Animation::move_animation(creature, Dirs::DOWN);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -249,7 +144,7 @@ void Action::hit(Creature* creature, float time, const std::vector<std::shared_p
         return;
     }
 
-    hit_animation(creature);
+    Animation::hit_animation(creature);
 }
 
 void Action::dying(Creature* creature, float time) {
@@ -269,5 +164,5 @@ void Action::dying(Creature* creature, float time) {
         return;
     }
 
-    die_animation(creature);
+    Animation::die_animation(creature);
 }

--- a/action/action.h
+++ b/action/action.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include "field.h"
 #include "creature.h"
+#include "animation.h"
 #include "utils.h"
 
 class Action
@@ -18,15 +19,8 @@ public:
     static void hit(Creature* creature, float time, const std::vector<std::shared_ptr<Creature>>& drawable_creatures);
     static void dying(Creature* creature, float time);
 
-
     // animation
-    static void switch_y_txt(Dirs dir, int& y_texture);
     static void update_frame(Creature* creature, float time);
-    static void move_animation(Creature* creature, Dirs dir);
-    static void stop_animation(Creature* creature);
-    static void hit_animation(Creature* creature);
-    static void die_animation(Creature* creature);
-
 
 private:
     // inner, additional functions

--- a/animation/CMakeLists.txt
+++ b/animation/CMakeLists.txt
@@ -1,8 +1,8 @@
-set(ProjectId action)
+set(ProjectId animation)
 project(${ProjectId})
 
 file(GLOB ALL_SOURCE_FILES *.cpp *.h *.hpp)
 
 add_library(${ProjectId} STATIC ${ALL_SOURCE_FILES})
 target_include_directories(${ProjectId} PUBLIC .)
-target_link_libraries(${ProjectId} tiles animation field creature armor_set utils)
+target_link_libraries(${ProjectId} creature)

--- a/animation/animation.cpp
+++ b/animation/animation.cpp
@@ -1,0 +1,143 @@
+#include "animation.h"
+
+void Animation::move_animation(Creature* creature, Dirs dir) {
+    switch (creature->get_anim()) { 
+    case (CreatureAnim::HUMANOID):
+        move_hum(creature, dir);
+        break;
+    }
+}
+
+void Animation::stop_animation(Creature* creature) {
+    switch (creature->get_anim()) {
+    case (CreatureAnim::HUMANOID):
+        stop_hum(creature);
+        break;
+    }
+}
+
+void Animation::hit_animation(Creature* creature) {
+    switch (creature->get_anim()) {
+    case (CreatureAnim::HUMANOID):
+        hit_hum(creature);
+        break;
+    }
+}
+
+void Animation::die_animation(Creature* creature) {
+    switch (creature->get_anim()) {
+    case (CreatureAnim::HUMANOID):
+        die_hum(creature);
+        break;
+    }
+}
+
+//=================================================================================================
+                                           // HUMANOID
+//=================================================================================================
+
+void Animation::move_hum(Creature* creature, Dirs dir) {
+    int y_texture = 0;
+    switch (dir) {
+        case (Dirs::LEFT):  y_texture = 64;     break;
+        case (Dirs::RIGHT): y_texture = 192;    break;
+        case (Dirs::UP):    y_texture = 0;      break;
+        case (Dirs::DOWN):  y_texture = 128;    break;
+    }
+    auto& pos = creature->get_pos();
+    auto& current_frame = creature->get_frame();
+    auto& armor_set = creature->get_armor();
+    auto& weapon = creature->get_weapon();
+
+    creature->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
+    creature->get_sprite().setTextureRect(
+            sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
+
+    for (int i = 0; i < armor_set.size(); ++i) {
+        if (armor_set[i] != nullptr) {
+            armor_set[i]->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
+            armor_set[i]->get_sprite().setTextureRect(
+                    sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
+        }
+    }
+
+    if (weapon != nullptr) {
+        weapon->get_sprite().setPosition(sf::Vector2f(pos.x, pos.y - 32));
+        weapon->get_sprite().setTextureRect(
+                sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
+    }
+
+    creature->direction = dir;
+}
+
+void Animation::stop_hum(Creature* creature) {
+    int y_texture = 0;
+    switch (creature->direction) {
+        case (Dirs::LEFT):  y_texture = 64;     break;
+        case (Dirs::RIGHT): y_texture = 192;    break;
+        case (Dirs::UP):    y_texture = 0;      break;
+        case (Dirs::DOWN):  y_texture = 128;    break;
+    }
+
+    auto& armor_set = creature->get_armor();
+    auto& weapon = creature->get_weapon();
+
+    creature->get_sprite().setTextureRect(sf::IntRect({0, y_texture}, {64, 64}));
+
+    for (int i = 0; i < armor_set.size(); ++i) {
+        if (armor_set[i] != nullptr) {
+            armor_set[i]->get_sprite().setTextureRect(sf::IntRect({0, y_texture}, {64, 64}));
+        }
+    }
+
+    if (weapon != nullptr)
+        weapon->get_sprite().setTextureRect(sf::IntRect({0, y_texture}, {64, 64}));
+}
+
+void Animation::hit_hum(Creature* creature) {
+    int y_texture = 0;
+    switch (creature->direction) {
+        case (Dirs::LEFT):  y_texture = 64;     break;
+        case (Dirs::RIGHT): y_texture = 192;    break;
+        case (Dirs::UP):    y_texture = 0;      break;
+        case (Dirs::DOWN):  y_texture = 128;    break;
+    }
+    auto& pos = creature->get_pos();
+    auto& current_frame = creature->get_frame();
+    auto& armor_set = creature->get_armor();
+    auto& weapon = creature->get_weapon();
+
+    creature->get_sprite().setTextureRect(
+            sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
+
+    for (int i = 0; i < armor_set.size(); ++i) {
+        if (armor_set[i] != nullptr) {
+            armor_set[i]->get_sprite().setTextureRect(
+                    sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, y_texture}, {64, 64}));
+        }
+    }
+
+    if (weapon != nullptr) {
+        weapon->get_sprite().setTextureRect(
+                sf::IntRect({(static_cast<int>(current_frame) + 1) * 192, y_texture * 3}, {192, 192}));
+        weapon->get_sprite().setPosition(sf::Vector2f(pos.x - 64, pos.y - 96));
+    }
+}
+
+void Animation::die_hum(Creature* creature) {
+    auto& current_frame = creature->get_frame();
+    auto& armor_set = creature->get_armor();
+    auto& weapon = creature->get_weapon();
+
+    creature->get_sprite().setTextureRect(sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, 0}, {64, 64}));
+
+    for (int i = 0; i < armor_set.size(); ++i) {
+        if (armor_set[i] != nullptr) {
+            armor_set[i]->get_sprite().setTextureRect(
+                    sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, 0}, {64, 64}));
+        }
+    }
+
+    if (weapon != nullptr)
+        weapon->get_sprite().setTextureRect(sf::IntRect({(static_cast<int>(current_frame) + 1) * 64, 0}, {64, 64}));
+}

--- a/animation/animation.h
+++ b/animation/animation.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <iostream>
+#include "creature.h"
+
+class Animation {
+public:
+    static void move_animation(Creature* creature, Dirs dir);
+    static void stop_animation(Creature* creature);
+    static void hit_animation(Creature* creature);
+    static void die_animation(Creature* creature);
+
+    // HUMANOID ===========================================
+    static void move_hum(Creature* creature, Dirs dir);
+    static void stop_hum(Creature* creature);
+    static void hit_hum(Creature* creature);
+    static void die_hum(Creature* creature);
+    // ====================================================
+
+    // SPIDER =============================================
+    //static void move_spider(Creature* creature, Dirs dir);
+    // ====================================================
+};
+

--- a/creature/Player/player.cpp
+++ b/creature/Player/player.cpp
@@ -6,6 +6,7 @@ class Action;
 Player::Player(CreatureManager& _manager, int _health, const sf::Vector2f& _pos)
         : Creature("man", _manager, _health, _pos) {
     creature_type = CreatureType::PLAYER;
+    creature_anim = CreatureAnim::HUMANOID;
 }
 
 void Player::action(sf::Event& event, float time, const std::shared_ptr<Field>& game_field,
@@ -51,7 +52,7 @@ void Player::action(sf::Event& event, float time, const std::shared_ptr<Field>& 
             event.type = sf::Event::KeyPressed;
             event.key.code = sf::Keyboard::LShift;
         } else {
-            Action::stop_animation(this);
+            Animation::stop_animation(this);
         }
     }
 }

--- a/creature/creature.cpp
+++ b/creature/creature.cpp
@@ -91,7 +91,7 @@ void Creature::show_creature(sf::RenderWindow& window) {
     if (direction == Dirs::UP)
         window.draw(get_weapon()->get_sprite());
 
-    for (auto el : get_armor().armor_set) {
+    for (auto& el : get_armor().armor_set) {
         if (el != nullptr)
             window.draw(el->get_sprite());
     }
@@ -176,12 +176,7 @@ void CreatureManager::creatureDied(Creature* creature) {
         // end game
         return;
     } else {
-        for (auto it = (*enemies).begin(); it != (*enemies).end(); ++it) {
-            if (it->get() == creature) {
-                (*enemies).erase(it);
-                break;
-            }
-        }
+        creature->to_delete_from_vector = true;
     }
 
     player->add_experience(10);

--- a/creature/creature.h
+++ b/creature/creature.h
@@ -11,6 +11,7 @@
 using json = nlohmann::json;
 
 enum class CreatureType { NONE, PLAYER, TRADER, BEETLE, TAUR, WOLF, SKELETON };
+enum class CreatureAnim { NONE, HUMANOID, SPIDER };
 
 enum class Dirs { LEFT, RIGHT, UP, DOWN };
 
@@ -29,6 +30,9 @@ public:
     // Methods
     CreatureType get_type() const {
         return creature_type;
+    }
+    CreatureAnim get_anim() const {
+        return creature_anim;
     }
     void reduce_health(int value);
     void add_experience(int exp);
@@ -93,6 +97,7 @@ protected:
     CreatureManager& manager;
 
     CreatureType creature_type = CreatureType::NONE;
+    CreatureAnim creature_anim = CreatureAnim::NONE;
 };
 
 class CreatureManager {

--- a/creature/creature.h
+++ b/creature/creature.h
@@ -77,6 +77,7 @@ public:
     }
 
     bool died = false;
+    bool to_delete_from_vector = false;
     bool stuck = false;
     float stuck_time = 3.f;
     Modes mode;

--- a/creature/enemy.cpp
+++ b/creature/enemy.cpp
@@ -31,5 +31,5 @@ void Enemy::action(float time) {
     if (died)
         Action::dying(this, time);
     else
-        Action::stop_animation(this);
+        Animation::stop_animation(this);
 }

--- a/creature/skeleton/skeleton.cpp
+++ b/creature/skeleton/skeleton.cpp
@@ -3,4 +3,5 @@
 Skeleton::Skeleton(CreatureManager& _manager, int _health, const sf::Vector2f& _pos)
         : Enemy("skeleton", _manager, _health, _pos) {
     creature_type = CreatureType::SKELETON;
+    creature_anim = CreatureAnim::HUMANOID;
 }

--- a/game/game.cpp
+++ b/game/game.cpp
@@ -24,9 +24,9 @@ Game::Game(sf::RenderWindow* _window) {
     player->set_armor(Boots::make_boots(BootsType::Boots_brown));
     player->set_weapon(Axe::make_axe(AxeType::Axe_basic));
 
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 300; ++i) {
         enemies.push_back(
-                Enemy::spawn_enemy(CreatureType::SKELETON, manager, 100, {(i % 7 + 1) * 200.f, (i / 7 + 1) * 256.f}));
+                Enemy::spawn_enemy(CreatureType::SKELETON, manager, 100, {(i % 20 + 1) * 70.f, (i / 20 + 1) * 70.f}));
         enemies[i]->set_armor(BodyArmor::make_body(BodyArmorType::BodyArmor_chain));
         enemies[i]->set_armor(Helmet::make_helmet(HelmetType::Helmet_chain_hood));
     }
@@ -75,9 +75,10 @@ View_mode Game::game_loop() {
         player->action(event, time, game_field, drawable_creatures);
         get_player_pos_for_view(player->get_pos());
 
-        for (auto& enemy : enemies) {
-            enemy->action(time);
+        for (int i = 0; i < enemies.size(); ++i) {
+            enemies[i]->action(time);
         }
+        Utils::delete_dead_creatures(enemies);
 
         last_event = std::move(event);
 

--- a/tests/creature_tests.cpp
+++ b/tests/creature_tests.cpp
@@ -5,6 +5,7 @@
 #include "creature.h"
 #include "enemy.h"
 #include "weapons.h"
+#include "utils.h"
 
 namespace {
 
@@ -92,6 +93,7 @@ TEST(CreatureTests, creature_death) {
     }
     enemies[2]->die();
     enemies[1]->die();
+    Utils::delete_dead_creatures(enemies);
     ASSERT_EQ(size, enemies.size() + 2);
 }
 

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -1,5 +1,18 @@
 #include "utils.h"
 
+void Utils::delete_dead_creatures(std::vector<std::shared_ptr<Enemy>>& enemies) {
+    std::size_t to_resize = enemies.size();
+    for (int i = 0; i < to_resize; ++i) {
+        if (enemies[i]->to_delete_from_vector) {
+            std::swap(enemies[i], enemies[--to_resize]);
+            if (enemies[i]->to_delete_from_vector) {
+                --i;
+            }
+        }
+    }
+    enemies.resize(to_resize);
+}
+
 std::vector<std::shared_ptr<Creature>> Utils::find_drawable_creatures(
         const std::vector<std::shared_ptr<Enemy>>& enemies, const std::vector<int>& object_borders) {
     int obj_top_border = object_borders[0];

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -5,6 +5,7 @@ enum class View_mode { NONE, EXIT, GAME, MAIN_MENU, PAUSE_MENU, SETTINGS_MENU, S
 
 class Utils {
 public:
+    static void delete_dead_creatures(std::vector<std::shared_ptr<Enemy>>& enemies);
     static std::vector<std::shared_ptr<Creature>> find_drawable_creatures(
             const std::vector<std::shared_ptr<Enemy>>& enemies, const std::vector<int>& object_borders);
 


### PR DESCRIPTION
Добавил enum для анимации, эдакая декомпозиция по типам анимации. В классе action вызываются методы класса Animation, внутри этих методов с помощью свича определяется нужная анимация. На производительность это не повлияет, так как пройти свичом по условно 10 кейсам совсем не сложная задача. С нашими 2к фпс потеря доли процента не выглядит страшной. При этом код мне кажется легко расширяемым. 
Случайно вышло, что фикс удаления из вектора оказался в этом же пр, но там буквально один метод добавился.