### PR TITLE
add_statistics

### DIFF
--- a/creature/creature.cpp
+++ b/creature/creature.cpp
@@ -264,6 +264,10 @@ void CreatureManager::setEnemies(std::vector<std::shared_ptr<Enemy>>* _enemies) 
     enemies = _enemies;
 }
 
+void CreatureManager::setTraders(std::vector<std::shared_ptr<Trader>>* _traders) {
+    traders = _traders;
+}
+
 void CreatureManager::setField(Field* _field) {
     field = _field;
 }

--- a/creature/creature.h
+++ b/creature/creature.h
@@ -161,9 +161,16 @@ protected:
 
 class CreatureManager {
 public:
-    CreatureManager() {}
+    CreatureManager() {
+        player = nullptr;
+        enemies = nullptr;
+        traders = nullptr;
+        field = nullptr;
+    }
+
     void setPlayer(Player* _player);
     void setEnemies(std::vector<std::shared_ptr<Enemy>>* _enemies);
+    void setTraders(std::vector<std::shared_ptr<Trader>>* _traders);
     void setField(Field* _field);
     void creatureDied(Creature* creature);
     ~CreatureManager() {}
@@ -171,5 +178,6 @@ public:
 private:
     Player* player;
     std::vector<std::shared_ptr<Enemy>>* enemies;
+    std::vector<std::shared_ptr<Trader>>* traders;
     Field* field;
 };

--- a/game/FPS_counter.cpp
+++ b/game/FPS_counter.cpp
@@ -3,31 +3,13 @@
 
 FPS_counter::FPS_counter() {
     on = true;
-    font = *Resources::FontsHolder::getResource("basic_font");
-    text_aver_fps.setFont(font);
-    text_aver_fps.setCharacterSize(16);
-    text_aver_fps.setStyle(sf::Text::Bold);
-    text_aver_fps.setFillColor(sf::Color(0, 240, 24));
-    text_aver_fps.setPosition(sf::Vector2f(10.f, 5.f));
 
-    text_max_fps.setFont(font);
-    text_max_fps.setCharacterSize(16);
-    text_max_fps.setStyle(sf::Text::Bold);
-    text_max_fps.setFillColor(sf::Color(0, 240, 24));
-    text_max_fps.setPosition(sf::Vector2f(10.f, 25.f));
-
-    text_min_fps.setFont(font);
-    text_min_fps.setCharacterSize(16);
-    text_min_fps.setStyle(sf::Text::Bold);
-    text_min_fps.setFillColor(sf::Color(0, 240, 24));
-    text_min_fps.setPosition(sf::Vector2f(10.f, 45.f));
-
-    text_aver_fps.setString("0");
-    text_max_fps.setString("0");
-    text_min_fps.setString("0");
+    init_text(text_aver_fps, 5);
+    init_text(text_max_fps, 25);
+    init_text(text_min_fps, 45);
 }
 
-void FPS_counter::add_time(float time, sf::RenderWindow& window) {
+void FPS_counter::add_time(float time) {
     frames_count++;
     elapsed_time += time;
     if (elapsed_time > 25.f) {
@@ -40,7 +22,20 @@ void FPS_counter::add_time(float time, sf::RenderWindow& window) {
         elapsed_time = 0.f;
         frames_count = 0;
     }
+}
+
+void FPS_counter::show(sf::RenderWindow& window) {
     window.draw(text_aver_fps);
     window.draw(text_max_fps);
     window.draw(text_min_fps);
+}
+
+void FPS_counter::init_text(sf::Text& text, float y) {
+    text.setFont(*Resources::FontsHolder::getResource("basic_font"));
+    text.setCharacterSize(16);
+    text.setStyle(sf::Text::Bold);
+    text.setOutlineThickness(1);
+    text.setFillColor(sf::Color(0, 240, 24));
+    text.setPosition(sf::Vector2f(10.f, y));
+    text.setString("0");
 }

--- a/game/FPS_counter.h
+++ b/game/FPS_counter.h
@@ -4,19 +4,25 @@
 #include "SFML/Graphics.hpp"
 
 class FPS_counter {
+public:
+    FPS_counter();
+    void add_time(float time);
+    void show(sf::RenderWindow& window);
+    bool on;
+
+    int get_aver() {
+        return aver_fps;
+    }
+
 private:
     float elapsed_time = 0.f;
     int frames_count = 0;
     int aver_fps = 0;
-    int min_fps = 1000;
+    int min_fps = 10000;
     int max_fps = 0;
-    sf::Font font;
     sf::Text text_aver_fps;
     sf::Text text_max_fps;
     sf::Text text_min_fps;
 
-public:
-    FPS_counter();
-    void add_time(float time, sf::RenderWindow& window);
-    bool on;
+    void init_text(sf::Text& text, float y);
 };

--- a/game/game.cpp
+++ b/game/game.cpp
@@ -7,33 +7,24 @@
 #include "items.h"
 #include "common_thing.h"
 
-//#define universal
-
-void Game::make_screenshot(const std::string& name) {
-    sf::Texture texture;
-    texture.create(window->getSize().x, window->getSize().y);
-    texture.update(*window);
-    sf::Image screenshot = texture.copyToImage();
-    screenshot.saveToFile("../../images/" + name + ".jpg");
-}
-
 Game::Game(sf::RenderWindow* _window, GameSettings& _settings): settings(_settings) {
 
-    std::mt19937 gen;
+    std::mt19937 random_for_init;
     auto now = std::chrono::high_resolution_clock::now();
-    gen.seed(static_cast<unsigned>(now.time_since_epoch().count()));
+    random_for_init.seed(static_cast<unsigned>(now.time_since_epoch().count()));
 
     window = _window;
+    multiplicator = 1.5f;
 
     game_field = std::shared_ptr<Field>(new Field(size, size));
     game_field->generate_field();
-    for (int i = 1; i <= 12; i++) {
+    for (int i = 1; i <= 1; i++) {
         (*game_field)(10, i * 2 + 20)->items.push_back(std::shared_ptr<Items>
-                    (new CommonThing("bone", 50, {32.f * (i * 2.f + 20.f), 32.f * 10.f})));
+                    (new CommonThing("bone", 1, {32.f * (i * 2.f + 20.f), 32.f * 10.f})));
         (*game_field)(12, i * 2 + 20)->items.push_back(std::shared_ptr<Items>
-                    (new CommonThing("antidote", 50, {32.f * (i * 2.f + 20.f), 32.f * 12.f})));
+                    (new CommonThing("antidote", 1, {32.f * (i * 2.f + 20.f), 32.f * 12.f})));
         (*game_field)(14, i * 2 + 20)->items.push_back(std::shared_ptr<Items>(
-                        new CommonThing("silver_necklace", 50, {32.f * (i * 2.f + 20.f), 32.f * 14.f})));
+                        new CommonThing("silver_necklace", 1, {32.f * (i * 2.f + 20.f), 32.f * 14.f})));
     }
     view.reset(sf::FloatRect({0, 0}, {1280, 720}));
 
@@ -41,6 +32,7 @@ Game::Game(sf::RenderWindow* _window, GameSettings& _settings): settings(_settin
     get_player_pos_for_view(player->get_pos());
     manager.setPlayer(player.get());
     manager.setEnemies(&enemies);
+    manager.setTraders(&traders);
     manager.setField(game_field.get());
 
     player->set_armor(BodyArmor::make_body(BodyArmorType::BodyArmor_leather));
@@ -51,9 +43,9 @@ Game::Game(sf::RenderWindow* _window, GameSettings& _settings): settings(_settin
     // player->set_weapon(Flail::make_flail());
     player->set_weapon(Halberd::make_halberd());
 
-    for (int i = 0; i < 15; ++i) {
+    for (int i = 0; i < 100; ++i) {
         enemies.push_back(
-                Enemy::spawn_enemy(CreatureType::SKELETON, manager, 100.f, {(i % 7 + 1) * 200.f, (i / 7 + 1) * 256.f}));
+                Enemy::spawn_enemy(CreatureType::SKELETON, manager, 100.f, {(i % 10 + 4) * 40.f, (i / 10 + 4) * 40.f}));
         enemies[i]->set_armor(BodyArmor::make_body(BodyArmorType::BodyArmor_chain));
         enemies[i]->set_armor(Helmet::make_helmet(HelmetType::Helmet_plate));
         enemies[i]->set_armor(Pants::make_pants(PantsType::Pants_plate));
@@ -64,12 +56,60 @@ Game::Game(sf::RenderWindow* _window, GameSettings& _settings): settings(_settin
     //             Enemy::spawn_enemy(CreatureType::SPIDER, manager, 100, {(i % 7 + 1) * 200.f, (i / 7 + 2) * 200.f}));
     // }
     for (int i = 0; i < 5; ++i) {
-        traders.push_back(std::shared_ptr<Trader>(new Trader(manager, 1000, {(i + 1) * 300.f, 600.f}, gen)));
+        traders.push_back(
+                std::shared_ptr<Trader>(new Trader(manager, 1000, {(i + 1) * 300.f, 600.f}, random_for_init)));
     }
 
     game_UI.update_UI(*player);
     // There will be a method that will load inventory from json
     InventoryMenu::build_inventory(player->inventory.get());
+}
+
+View_mode Game::check_event(sf::Event& event, float time) {
+    if (event.type == sf::Event::Closed) {
+        return View_mode::EXIT;
+    }
+
+    if (player->dead) {
+        countdown_before_gameover_screen += time;
+        if (countdown_before_gameover_screen > 5.f) {
+            make_screenshot("tmp_gameover");
+            return View_mode::GAMEOVER_MENU;
+        }
+    }
+
+    if (event.type == sf::Event::KeyPressed) {
+        switch (event.key.code) {
+        case (sf::Keyboard::Tab):
+            return View_mode::SKILLS_MENU;
+        case (sf::Keyboard::M):
+            return View_mode::MAP_MENU;
+        case (sf::Keyboard::Tilde):
+            fps.on = !fps.on;
+            break;
+        case (sf::Keyboard::F1):
+            statistics.on = !statistics.on;
+            break;
+        case (sf::Keyboard::B):
+            show_boxes = !show_boxes;
+            break;
+        case (sf::Keyboard::Escape):
+            make_screenshot("tmp_pause");
+            return View_mode::PAUSE_MENU;
+        case (sf::Keyboard::E):
+            InventoryMenu::update_graphic_inventory(player->inventory.get(), player->inventory.get_money());
+            make_screenshot("tmp_inventory");
+            return View_mode::INVENTORY_MENU;
+        case (sf::Keyboard::T):
+            InventoryMenu::update_graphic_inventory(player->available_trader->inventory.get(),
+                                                    player->available_trader->inventory.get_money());
+            make_screenshot("tmp_inventory");
+            return View_mode::INVENTORY_MENU;
+        default:
+            break;
+        }
+    }
+    return View_mode::NONE;
 }
 
 View_mode Game::game_loop() {
@@ -79,102 +119,95 @@ View_mode Game::game_loop() {
     window->pollEvent(event);
     window->pollEvent(last_event);
 
+    event.type = sf::Event::GainedFocus;
+    last_event.type = sf::Event::GainedFocus;
+
     while (window->isOpen()) {
-        // The regulator of game speed
-        auto time = clock.getElapsedTime().asMicroseconds() / 15000.f;
+        auto time = clock.getElapsedTime().asMicroseconds() / (multiplicator * 10000);
         clock.restart();
+
+        if (fps.on) {
+            fps.add_time(time * multiplicator);
+        }
+        if (statistics.on) {
+            statistics.update(time, fps.get_aver(), enemies.size(), traders.size(),
+                                             drawable_creatures.size());
+        }
+
         window->pollEvent(event);
-
-        if (event.type == sf::Event::Closed) {
-            return View_mode::EXIT;
-        }
-
-        if (event.type == sf::Event::KeyPressed) {
-            switch (event.key.code) {
-            case (sf::Keyboard::Tab):
-                return View_mode::SKILLS_MENU;
-            case (sf::Keyboard::M):
-                return View_mode::MAP_MENU;
-            case (sf::Keyboard::Tilde):
-                fps.on = !fps.on;
-                break;
-            case (sf::Keyboard::B):
-                show_boxes = !show_boxes;
-                break;
-            case (sf::Keyboard::Escape):
-                make_screenshot("tmp_pause");
-                return View_mode::PAUSE_MENU;
-            case (sf::Keyboard::E):
-                InventoryMenu::update_graphic_inventory(player->inventory.get(), player->inventory.get_money());
-                make_screenshot("tmp_inventory");
-                return View_mode::INVENTORY_MENU;
-            case (sf::Keyboard::T):
-                if (player->can_accept_request) {
-                    InventoryMenu::update_graphic_inventory(player->available_trader->inventory.get(),
-                                                            player->available_trader->inventory.get_money());
-                    make_screenshot("tmp_inventory");
-                    return View_mode::INVENTORY_MENU;
-                }
-                break;
-            default:
-                break;
-            }
-        }
-
+        View_mode to_return = check_event(event, time);
+        if (to_return != View_mode::NONE)
+            return to_return;
         Utils::clear_event(event, last_event, player);
 
-        player->action(event, time, game_field.get(), drawable_creatures);
-        get_player_pos_for_view(player->get_pos());
+        frame_calculation(time, event, last_event);
+        
+        render();
 
-        for (auto& enemy : enemies) {
-            enemy->action(time, game_field.get(), player.get(), settings.difficulty);
-        }
-
-        for (auto& trader : traders) {
-            trader->action(time, player.get());
-        }
-
-        if (player->dead) {
-            countdown_before_gameover_screen += time;
-            if (countdown_before_gameover_screen > 5.f) {
-                make_screenshot("tmp_gameover");
-                return View_mode::GAMEOVER_MENU;
-            }
-        }
-
-        Utils::delete_dead_creatures(enemies, traders);
-        Utils::detect_collisions(drawable_creatures);
-
-        last_event = std::move(event);
-
-        game_UI.update_UI(*player);
-        render(time);
-        Cursor::move(*window);
-        window->display();
         Screen::play_music();
     }
     return View_mode::NONE;
 }
 
-void Game::render(float time) {
-    // RENDERING DYNAMIC OBJECTS
-    window->setView(view);
-    window->clear(sf::Color(0, 0, 0));
-    auto borders = Utils::get_rendering_borders(window->getSize().x, window->getSize().y, game_field->get_width(),
+void Game::frame_calculation(float time, sf::Event& event, sf::Event& last_event) {
+    // ACTIONS //////////////////////////////////////////////////////
+    statistics.start();
+    player->action(event, time, game_field.get(), drawable_creatures);
+    for (auto& enemy : enemies) {
+        enemy->action(time, game_field.get(), player.get(), settings.difficulty);
+    }
+    for (auto& trader : traders) {
+        trader->action(time, player.get());
+    }
+    statistics.stop(ACTIONS_STAT);
+    /////////////////////////////////////////////////////////////////
+
+    // UTILS SECTION ////////////////////////////////////////////////
+    statistics.start();
+    borders = Utils::get_rendering_borders(window->getSize().x, window->getSize().y, game_field->get_width(),
                                                 game_field->get_height(), player->get_pos());
-    auto object_borders = Utils::get_object_borders(borders, game_field->get_width(), game_field->get_height());
+    object_borders = Utils::get_object_borders(borders, game_field->get_width(), game_field->get_height());
+
+    Utils::delete_dead_creatures(enemies, traders);
+
+    Utils::detect_collisions(drawable_creatures);
+
     drawable_creatures = Utils::find_drawable_creatures(enemies, traders, object_borders);
-    if (!player->dead)
+
+    if (!player->dead) {
         drawable_creatures.push_back(player);
+    }
+
     Utils::sort_drawable_creatures(drawable_creatures);
+
+    game_UI.update_UI(*player);
+    last_event = std::move(event);
+    statistics.stop(PROCESSING_STAT);
+    /////////////////////////////////////////////////////////////////
+}
+
+void Game::render() {
+    statistics.start();
+    window->clear(sf::Color(0, 0, 0));
+
+    // RENDERING DYNAMIC OBJECTS
+    get_player_pos_for_view(player->get_pos());
+    window->setView(view);
     Drawer::show_everything(*window, game_field, borders, object_borders, drawable_creatures, show_boxes);
 
     // RENDERING STATIC UI ELEMENTS
     window->setView(window->getDefaultView());
     game_UI.show_UI(*window);
     if (fps.on) {
-        fps.add_time(time, *window);
+        fps.show(*window);
     }
+    if (statistics.on) {
+        statistics.show(*window);
+    }
+
+    Cursor::move(*window);
+    window->display();
+    statistics.stop(RENDER_STAT);
 }
 
 sf::View Game::get_player_pos_for_view(const sf::Vector2f& pos) {
@@ -192,6 +225,14 @@ sf::View Game::get_player_pos_for_view(const sf::Vector2f& pos) {
 
     view.setCenter(sf::Vector2f(temp_x, temp_y));
     return view;
+}
+
+void Game::make_screenshot(const std::string& name) {
+    sf::Texture texture;
+    texture.create(window->getSize().x, window->getSize().y);
+    texture.update(*window);
+    sf::Image screenshot = texture.copyToImage();
+    screenshot.saveToFile("../../images/" + name + ".jpg");
 }
 
 bool Game::save(const std::string& file_name) const {

--- a/game/game.h
+++ b/game/game.h
@@ -5,35 +5,18 @@
 #include "enemies/enemy.h"
 #include "field.h"
 #include "game_settings.h"
+#include "game_statistics.h"
 #include "game_ui.h"
 #include "player/player.h"
 #include "trader/trader.h"
 
+#define ACTIONS_STAT 1
+#define PROCESSING_STAT 2
+#define RENDER_STAT 3
+
 class Game {
-private:
-    sf::RenderWindow* window;
-    int size = 1024;
-    std::shared_ptr<Field> game_field;
-    int game_region_width = size * 32;  // size in pixels
-    int game_region_height = size * 32;
-    std::shared_ptr<Player> player;
-    std::vector<std::shared_ptr<Enemy>> enemies;
-    std::vector<std::shared_ptr<Trader>> traders;
-    std::vector<std::shared_ptr<Creature>> drawable_creatures;
-    CreatureManager manager;
-    GameSettings& settings;
-    sf::View view;
-
-    void make_screenshot(const std::string& name);
-
 public:
     Game(sf::RenderWindow* _window, GameSettings& _settings);
-    FPS_counter fps;
-    GameUI game_UI;
-
-    // additional information
-    bool show_boxes = false;
-    float countdown_before_gameover_screen = 0.f;
 
     // Main loop
     View_mode game_loop();
@@ -43,7 +26,36 @@ public:
         return player;
     }
 
+private:
+    sf::RenderWindow* window;
+    int size = 1024;
+    std::shared_ptr<Field> game_field;
+    int game_region_width = size * 32;  // size in pixels
+    int game_region_height = size * 32;
+    std::vector<int> borders;
+    std::vector<int> object_borders;
+    std::shared_ptr<Player> player;
+    std::vector<std::shared_ptr<Enemy>> enemies;
+    std::vector<std::shared_ptr<Trader>> traders;
+    std::vector<std::shared_ptr<Creature>> drawable_creatures;
+    CreatureManager manager;
+    GameSettings& settings;
+    sf::View view;
+    float multiplicator;
+
+    // Gui
+    FPS_counter fps;
+    GameStatistics statistics;
+    GameUI game_UI;
+
+    // Additional information
+    bool show_boxes = false;
+    float countdown_before_gameover_screen = 0.f;
+
     // Game methods
-    void render(float time);
+    void frame_calculation(float time, sf::Event& event, sf::Event& last_event);
+    void render();
     sf::View get_player_pos_for_view(const sf::Vector2f&);
+    void make_screenshot(const std::string& name);
+    View_mode check_event(sf::Event& event, float time);
 };

--- a/game/game_statistics.cpp
+++ b/game/game_statistics.cpp
@@ -1,0 +1,84 @@
+#include "game_statistics.h"
+
+GameStatistics::GameStatistics() {
+    on = false;
+    elapsed_time = 0.f;
+    act_count = proc_count = rend_count = 0;
+    act_time = proc_time = rend_time = 0.0;
+
+    init_text(all_creatures_amount, 80.f);
+    init_text(drawable_creatures_amount, 100.f);
+
+    init_text(creatures_actions, 135.f);
+    init_text(creatures_processing, 155.f);
+    init_text(render, 175.f);
+}
+
+void GameStatistics::update(float time, int aver, size_t enemies_size,
+                                       size_t traders_size, size_t drawable_creatures_size) {
+    elapsed_time += time;
+    double frame = 1.0 / aver;
+    if (elapsed_time > 100.f) {
+        all_creatures_amount.setString("Total creatures: " +
+                                       std::to_string(enemies_size + traders_size + 1));  // +1 player
+        drawable_creatures_amount.setString("Visible creatures: " + std::to_string(drawable_creatures_size));
+
+        creatures_actions.setString("Actions: " + std::to_string(act_time / act_count) + " s, (" +
+                                    std::to_string((act_time / act_count) / frame * 100.0) + "%)");
+        creatures_processing.setString("Processing: " + std::to_string(proc_time / proc_count) + " s, (" +
+                                       std::to_string((proc_time / proc_count) / frame * 100.0) + "%)");
+        render.setString("Render: " + std::to_string(rend_time / rend_count) + " s, (" +
+                         std::to_string((rend_time / rend_count) / frame * 100.0) + "%)");
+        
+        elapsed_time = 0.f;
+        act_count = proc_count = rend_count = 0;
+        act_time = proc_time = rend_time = 0.0;
+    }
+}
+
+void GameStatistics::show(sf::RenderWindow& window) {
+    window.draw(all_creatures_amount);
+    window.draw(drawable_creatures_amount);
+    window.draw(creatures_actions);
+    window.draw(creatures_processing);
+    window.draw(render);
+}
+
+void GameStatistics::start() {
+    if (on) {
+        _start_ = std::chrono::high_resolution_clock::now();
+    }
+}
+
+void GameStatistics::stop(int counter) {
+    if (on) {
+        _stop_ = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> diff = _stop_ - _start_;
+        switch (counter) {
+        case 1:
+            act_time += diff.count();
+            act_count++;
+            break;
+        case 2:
+            proc_time += diff.count();
+            proc_count++;
+            break;
+        case 3:
+            rend_time += diff.count();
+            rend_count++;
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void GameStatistics::init_text(sf::Text& text, float y) {
+    text.setFont(*Resources::FontsHolder::getResource("basic_font"));
+    text.setCharacterSize(16);
+    text.setOutlineThickness(1);
+    text.setStyle(sf::Text::Bold);
+    text.setFillColor(sf::Color(0, 240, 24));
+    text.setPosition(sf::Vector2f(10.f, y));
+    text.setString("0");
+}

--- a/game/game_statistics.h
+++ b/game/game_statistics.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <iostream>
+#include "ResourceHolder.h"
+#include "SFML/Graphics.hpp"
+#include "FPS_counter.h"
+#include "enemies/enemy.h"
+
+class GameStatistics {
+public:
+    GameStatistics();
+    void update(float time, int aver, size_t enemies_size, size_t traders_size, size_t drawable_creatures_size);
+    void show(sf::RenderWindow& window);
+    bool on;
+
+    void start();
+    void stop(int counter);
+
+private:
+    sf::Text all_creatures_amount;
+    sf::Text drawable_creatures_amount;
+
+    sf::Text creatures_actions;
+    sf::Text creatures_processing;
+    sf::Text render;
+
+    void init_text(sf::Text& text, float y);
+
+    std::chrono::high_resolution_clock::time_point _start_;
+    std::chrono::high_resolution_clock::time_point _stop_;
+
+    int act_count;
+    int proc_count;
+    int rend_count;
+
+    double act_time;
+    double proc_time;
+    double rend_time;
+
+    float elapsed_time;
+};

--- a/interfaces/screen/game_ui.cpp
+++ b/interfaces/screen/game_ui.cpp
@@ -240,7 +240,7 @@ void GameUI::show_UI(sf::RenderWindow& window, std::vector<bool> opened_mechanic
 void GameUI::check_settings_cogwheel(sf::Vector2i mouse_pos) {
     if (mouse_pos.x > stats_bar_x + 18.f && mouse_pos.x < stats_bar_x + 46.f &&
         mouse_pos.y > stats_bar_y + 18.f && mouse_pos.y < stats_bar_y + 46.f) {  
-        cogwheel_sprite.rotate(sf::degrees(1.f));
+        cogwheel_sprite.rotate(sf::degrees(0.5f));
         if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left) && !cogwheel_pressed) {
             show_settings = !show_settings;
             cogwheel_pressed = true;

--- a/interfaces/screen/gameover_menu.cpp
+++ b/interfaces/screen/gameover_menu.cpp
@@ -23,6 +23,7 @@ View_mode GameoverMenu::Run(sf::RenderWindow& window) {
 
     sf::Event event;
     window.pollEvent(event);
+    event.type = sf::Event::GainedFocus;
     View_mode to_return{View_mode::NONE};
     window.setView(window.getDefaultView());
     while (true) {

--- a/interfaces/screen/inventory_menu.cpp
+++ b/interfaces/screen/inventory_menu.cpp
@@ -144,6 +144,7 @@ View_mode InventoryMenu::Run(sf::RenderWindow& window) {
 
     sf::Event event;
     window.pollEvent(event);
+    event.type = sf::Event::GainedFocus;
     View_mode to_return{View_mode::NONE};
     window.setView(window.getDefaultView());
     while (true) {

--- a/interfaces/screen/main_menu.cpp
+++ b/interfaces/screen/main_menu.cpp
@@ -14,6 +14,7 @@ MainMenu::MainMenu()
 View_mode MainMenu::Run(sf::RenderWindow& window) {
     sf::Event event;
     window.pollEvent(event);
+    event.type = sf::Event::GainedFocus;
     View_mode to_return{View_mode::NONE};
     window.setView(window.getDefaultView());
     while (true) {

--- a/interfaces/screen/map_menu.cpp
+++ b/interfaces/screen/map_menu.cpp
@@ -7,6 +7,7 @@ MapMenu::MapMenu() {
 View_mode MapMenu::Run(sf::RenderWindow& window) {
     sf::Event event;
     window.pollEvent(event);
+    event.type = sf::Event::GainedFocus;
     window.setView(window.getDefaultView());
     while (true) {
         window.pollEvent(event);

--- a/interfaces/screen/pause_menu.cpp
+++ b/interfaces/screen/pause_menu.cpp
@@ -23,6 +23,7 @@ View_mode PauseMenu::Run(sf::RenderWindow& window) {
 
     sf::Event event;
     window.pollEvent(event);
+    event.type = sf::Event::GainedFocus;
     View_mode to_return{View_mode::NONE};
     window.setView(window.getDefaultView());
     while (true) {

--- a/interfaces/screen/settings_menu.cpp
+++ b/interfaces/screen/settings_menu.cpp
@@ -14,6 +14,7 @@ SettingsMenu::SettingsMenu(GameSettings& _settings)
 View_mode SettingsMenu::Run(sf::RenderWindow& window) {
     sf::Event event;
     window.pollEvent(event);
+    event.type = sf::Event::GainedFocus;
     View_mode to_return{View_mode::NONE};
     window.setView(window.getDefaultView());
     while (true) {

--- a/interfaces/screen/skills_menu.cpp
+++ b/interfaces/screen/skills_menu.cpp
@@ -31,6 +31,7 @@ void SkillsMenu::node_click_checker(sf::Vector2i mouse_pos, const std::vector<st
 View_mode SkillsMenu::Run(sf::RenderWindow& window, Player* player) {
     sf::Event event;
     window.pollEvent(event);
+    event.type = sf::Event::GainedFocus;
     View_mode to_return{View_mode::NONE};
     window.setView(window.getDefaultView());
     while (true) {

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -143,7 +143,8 @@ void Utils::clear_event(sf::Event& event, sf::Event& last_event, std::shared_ptr
     if (event.type == sf::Event::MouseMoved || event.type == sf::Event::MouseWheelScrolled ||
         event.type == sf::Event::MouseLeft || event.type == sf::Event::MouseEntered ||
         event.type == sf::Event::MouseButtonPressed || event.type == sf::Event::MouseButtonReleased ||
-        sf::Keyboard::isKeyPressed(sf::Keyboard::Tilde) || sf::Keyboard::isKeyPressed(sf::Keyboard::B)) {
+        sf::Keyboard::isKeyPressed(sf::Keyboard::Tilde) || sf::Keyboard::isKeyPressed(sf::Keyboard::B) ||
+        sf::Keyboard::isKeyPressed(sf::Keyboard::F1) || sf::Keyboard::isKeyPressed(sf::Keyboard::T)) {
         event = std::move(last_event);
     }
 


### PR DESCRIPTION
1) Добавил подсчёт затрачиваемых ресурсов для игры. Выяснил, что рендер занимает до 95% времени кадра, из них 10% это window.display(). Чем больше на карте существ, тем больше тратится на actions и processing (до 10% на каждый).
2) Обнаружил, что fps высчитывался неправильно, у нас было ровно в полтора раза завышенное число. Исправил.
3) Добавил торговцев в менеджера
4) Форматировал класс game:
- пересмотрел спецификаторы доступа
- декомпозировал методы (check_event, frame_calculation)
- навёл порядок в game_loop
5) Исправил баги, связанные с релизом (инициировал event.type для каждого меню)